### PR TITLE
fix: Remove filter warning from About page in Explorer sidebar

### DIFF
--- a/inst/fred_explorer/ui.R
+++ b/inst/fred_explorer/ui.R
@@ -221,10 +221,10 @@ ui <- tagList(
     ")))
   ),
   tags$script(HTML("
+      var tabsWithoutSidebar = ['Dataset', 'References-Checker [alpha]', 'References', 'FAQ', 'About'];
+      var tabsWithWarning = ['Dataset', 'References-Checker [alpha]', 'References'];
       $(document).on('shiny:inputchanged', function(event) {
         if (event.name === 'navbar') {
-          var tabsWithoutSidebar = ['Dataset', 'References-Checker [alpha]', 'References', 'FAQ', 'About'];
-          var tabsWithWarning = ['Dataset', 'References-Checker [alpha]', 'References'];
           if (tabsWithoutSidebar.includes(event.value)) {
             $('#sidebar .shiny-input-container').not('#success_criterion').addClass('disabled');
             if (tabsWithWarning.includes(event.value)) {

--- a/inst/fred_explorer/ui.R
+++ b/inst/fred_explorer/ui.R
@@ -224,9 +224,14 @@ ui <- tagList(
       $(document).on('shiny:inputchanged', function(event) {
         if (event.name === 'navbar') {
           var tabsWithoutSidebar = ['Dataset', 'References-Checker [alpha]', 'References', 'FAQ', 'About'];
+          var tabsWithWarning = ['Dataset', 'References-Checker [alpha]', 'References'];
           if (tabsWithoutSidebar.includes(event.value)) {
             $('#sidebar .shiny-input-container').not('#success_criterion').addClass('disabled');
-            $('#sidebar-note').show();
+            if (tabsWithWarning.includes(event.value)) {
+              $('#sidebar-note').show();
+            } else {
+              $('#sidebar-note').hide();
+            }
           } else {
             $('#sidebar .shiny-input-container').removeClass('disabled');
             $('#sidebar-note').hide();


### PR DESCRIPTION
Fixes #86

Removes the inappropriate "Filtering is disabled" warning from the Explorer sidebar when viewing the About page.

## Changes
- Modified JavaScript logic in `ui.R` to only show filtering warning on contextually relevant tabs
- About and FAQ pages now disable sidebar without showing the warning
- Dataset, References-Checker, and References pages still show appropriate warning

## Testing
The About page should no longer display the confusing filter warning while maintaining proper sidebar behavior on other tabs.

Generated with [Claude Code](https://claude.ai/code)